### PR TITLE
refactor : article entity --> bulider 추가

### DIFF
--- a/board/src/main/java/kim/zhyun/board/domain/Article.java
+++ b/board/src/main/java/kim/zhyun/board/domain/Article.java
@@ -1,10 +1,7 @@
 package kim.zhyun.board.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -15,8 +12,8 @@ import java.time.LocalDateTime;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @ToString
-@Getter
-@AllArgsConstructor(staticName = "of")
+@Getter @Builder
+@AllArgsConstructor
 @NoArgsConstructor
 @DynamicUpdate
 @EntityListeners(AuditingEntityListener.class)
@@ -39,10 +36,4 @@ public class Article {
     @LastModifiedDate
     private LocalDateTime modifiedAt;
     
-    
-    public Article update(String title, String content) {
-        this.title = title;
-        this.content = content;
-        return this;
-    }
 }

--- a/board/src/test/java/kim/zhyun/board/repository/ArticleRepositoryTest.java
+++ b/board/src/test/java/kim/zhyun/board/repository/ArticleRepositoryTest.java
@@ -44,7 +44,9 @@ class ArticleRepositoryTest {
     @DisplayName("게시글 등록 테스트 - 게시글 1개")
     public void insert_and_read_article_all() {
         // given
-        Article article = Article.of(null, "title 1", "content 1", null, null);
+        Article article = Article.builder()
+                .title("title 1")
+                .content("content 1").build();
         
         // when
         Article saved = repository.save(article);
@@ -66,12 +68,14 @@ class ArticleRepositoryTest {
         insertDummyData();
         
         Article read1L = repository.getReferenceById(1L);
-        
+
         // when
-        Article updated = repository.saveAndFlush(
-                read1L.update(read1L.getTitle() + " update 고고",
-                        read1L.getContent() + " update 고고"));
-        
+        Article updated = repository.save(Article.builder()
+                .id(read1L.getId())
+                .title(read1L.getTitle() + " update 고고")
+                .content(read1L.getContent() + " update 고고")
+                .createdAt(read1L.getCreatedAt()).build());
+
         //then
         assertThat(repository.getReferenceById(1L)).isEqualTo(updated);
         
@@ -151,8 +155,9 @@ class ArticleRepositoryTest {
     private void insertDummyData() {
         List<Article> dummyInsert = new ArrayList<>();
         IntStream.rangeClosed(1, 10)
-                .forEach(idx -> dummyInsert.add(
-                        Article.of(null, "title " + idx, "content " + idx, null, null)));
+                .forEach(idx -> dummyInsert.add(Article.builder()
+                        .title("title " + idx)
+                        .content("content " + idx).build()));
         
         System.out.println("💁------- dummy data inserted ------------------------------------------------------------------------------------------------------┐");
         repository.saveAll(dummyInsert);


### PR DESCRIPTION
article entity에 update() 메서드를 작성해서 사용하고자 했었는데,
객체의 불변성을 위해 Builder 패턴을 적용하는 걸 권장 받아서 수정 진행
<br>


### Article.java
- update() 제거
- 클래스 단위에 @Builder 어노테이션 추가
- @AllArgsConstructor의 staticName 제거
<br>

### ArticleRepositoryTest.java
- Article.java 수정으로 인한 변경 사항 적용
<br>


---

jira issue key : SB-2