### PR TITLE
refactor : @EnableJpaAuditing 위치 이동

### DIFF
--- a/board/src/main/java/kim/zhyun/board/BoardApplication.java
+++ b/board/src/main/java/kim/zhyun/board/BoardApplication.java
@@ -2,9 +2,7 @@ package kim.zhyun.board;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class BoardApplication {
     

--- a/board/src/main/java/kim/zhyun/board/config/JpaAuditingConfig.java
+++ b/board/src/main/java/kim/zhyun/board/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package kim.zhyun.board.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}


### PR DESCRIPTION
Spring Boot 시작 위치인 BoardApplication에 있던 @EnableJpaAuditing 어노테이션을 별도의 설정파일로 분리. 시작위치에 두면 모든 단위테스트에 jpa auditing 관련 설정을 해주어야 한다.

- 참고 : https://velog.io/@suujeen/Error-creating-bean-with-name-jpaAuditingHandler

jira issue key : SB-4