### PR TITLE
에러 수정 : 테스트 1건 , 엔티티 관련 1건

### DIFF
--- a/board/src/main/java/kim/zhyun/board/data/ArticleCreateRequest.java
+++ b/board/src/main/java/kim/zhyun/board/data/ArticleCreateRequest.java
@@ -22,9 +22,7 @@ public class ArticleCreateRequest {
     private String content;
     
     public static Article to(ArticleCreateRequest request) {
-        return Article.builder()
-                .title(request.getTitle())
-                .content(request.getContent()).build();
+        return Article.of(null, request.getTitle(), request.getContent(), null, null);
     }
     
     @Override

--- a/board/src/main/java/kim/zhyun/board/data/ArticleUpdateRequest.java
+++ b/board/src/main/java/kim/zhyun/board/data/ArticleUpdateRequest.java
@@ -1,7 +1,6 @@
 package kim.zhyun.board.data;
 
 import jakarta.validation.constraints.NotEmpty;
-import kim.zhyun.board.domain.Article;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,13 +21,7 @@ public class ArticleUpdateRequest {
     
     @NotEmpty(message = "내용을 입력해주세요")
     private String content;
-    
-    public static Article to(ArticleUpdateRequest request) {
-        return Article.builder()
-                .id(request.getId())
-                .title(request.getTitle())
-                .content(request.getContent()).build();
-    }
+
     
     @Override
     public boolean equals(Object obj) {

--- a/board/src/main/java/kim/zhyun/board/domain/Article.java
+++ b/board/src/main/java/kim/zhyun/board/domain/Article.java
@@ -12,8 +12,8 @@ import java.time.LocalDateTime;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @ToString
-@Getter @Builder
-@AllArgsConstructor
+@Getter @Setter
+@AllArgsConstructor(staticName = "of")
 @NoArgsConstructor
 @DynamicUpdate
 @EntityListeners(AuditingEntityListener.class)

--- a/board/src/main/java/kim/zhyun/board/service/impl/ArticleServiceImpl.java
+++ b/board/src/main/java/kim/zhyun/board/service/impl/ArticleServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import static kim.zhyun.board.data.type.ExceptionType.ARTICLE_NOT_FOUND;
@@ -48,10 +49,14 @@ public class ArticleServiceImpl implements ArticleService {
     
     @Override
     public void update(ArticleUpdateRequest request) {
-        if (!articleRepository.existsById(request.getId()))
+        Optional<Article> article = articleRepository.findById(request.getId());
+        
+        if (article.isEmpty())
             throw new ArticleNotFoundException(ARTICLE_NOT_FOUND);
         
-        articleRepository.save(ArticleUpdateRequest.to(request));
+        Article source = article.get();
+        source.setTitle(request.getTitle());
+        source.setContent(request.getContent());
     }
     
     @Override

--- a/board/src/test/java/kim/zhyun/board/repository/ArticleRepositoryTest.java
+++ b/board/src/test/java/kim/zhyun/board/repository/ArticleRepositoryTest.java
@@ -1,12 +1,12 @@
 package kim.zhyun.board.repository;
 
-import jakarta.persistence.EntityListeners;
+import kim.zhyun.board.config.JpaAuditingConfig;
 import kim.zhyun.board.domain.Article;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.context.annotation.Import;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +16,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("DB Test")
-@EntityListeners(AuditingEntityListener.class)
+@Import(JpaAuditingConfig.class)
 @DataJpaTest
 class ArticleRepositoryTest {
     

--- a/board/src/test/java/kim/zhyun/board/service/ArticleServiceTest.java
+++ b/board/src/test/java/kim/zhyun/board/service/ArticleServiceTest.java
@@ -112,6 +112,7 @@ class ArticleServiceTest {
         
         // when
         service.update(request);
+        repository.flush();
         
         // then
         ArticleDto updatedArticle = service.findById(id);
@@ -121,6 +122,8 @@ class ArticleServiceTest {
 
         assertThat(updatedArticle).usingRecursiveComparison().isNotEqualTo(beforeArticle);
         assertThat(actual).usingRecursiveComparison().isEqualTo(updatedArticle);
+        assertThat(updatedArticle.getCreatedAt()).isEqualTo(beforeArticle.getCreatedAt());
+        assertThat(updatedArticle.getModifiedAt()).isNotEqualTo(beforeArticle.getModifiedAt());
     }
     
     @DisplayName("게시글 삭제 - 게시글 1개 삭제")
@@ -166,9 +169,8 @@ class ArticleServiceTest {
     public void insertDummyData() {
         List<Article> dummyInsert = new ArrayList<>();
         IntStream.rangeClosed(1, 10)
-                .forEach(idx -> dummyInsert.add(Article.builder()
-                        .title("title " + idx)
-                        .content("content " + idx).build()));
+                .forEach(idx -> dummyInsert.add(
+                        Article.of(null, "title " + idx, "content " + idx, null, null)));
         
         System.out.println("💁------- dummy data inserted ------------------------------------------------------------------------------------------------------┐");
         repository.saveAll(dummyInsert);


### PR DESCRIPTION
전체 테스트 시 발생하지 않고 있던 테스트 실패와 게시글 수정시 createdAt 필드에 null이 저장되고 있던 것을 수정

## 수정 정보
###  7635e469bb6406ec4a1ff48bd3f557e9b209fb42

#### Article.java
- @Builder 제거
- @Setter 추가
- @AllArgsConstructor 속성으로 staticName = "of" 추가
<br>

#### ArticleUpdateRequest.java
- Article의 setter 사용으로 팩토리 메서드 to() 제거
<br>

#### ArticleCreateRequest.java
- Article의 @builder 제거로 팩토리 메서드 of() 사용
<br>

#### ArticleServiceImpl.java
- update() 메서드 내용 수정
<br>

#### ArticleServiceTest.java
- ArticleServiceImpl의 update() 코드 변경으로 인한 update() 메서드 변경
- 생성일자, 수정일자 검증 추가
<br>

###  b3a9d528d755411ca5a23c8f71d2f9bcc9939fd5
####  ArticleRepositoryTest.java
- @EntityListeners(AuditingEntityListener.class) 제거
- @Import(JpaAuditingConfig.class) 추가
<br>

---

jira issue key : SB-9